### PR TITLE
Removing "upgrading" response, alter "logs" response

### DIFF
--- a/logs.md
+++ b/logs.md
@@ -6,7 +6,7 @@ If you dont have access to the dashboard you can find your logfiles in the follo
 
 - For Linux: `/var/lib/jellyfin/logs`
 - For Windows: `%programdata%/jellyfin/logs`
-- For Docker: You need to [mount](https://docs.docker.com/engine/storage/bind-mounts/) your config directory and then navigate to that mounts folder /logs
+- For Docker: On the docker host, the directory you map in as /config will have a "logs" directory in it.
 
 We recommend an external site like
 

--- a/upgrades.alias
+++ b/upgrades.alias
@@ -1,1 +1,0 @@
-upgrading

--- a/upgrading.md
+++ b/upgrading.md
@@ -1,5 +1,0 @@
-Upgrading from 10.10.7 to 10.11.7 (the recommended path, don't go to an earlier version of 10.11 first) changes the underlying data. While various migration bugs have been fixed in previous versions of 10.11, it's still highly recommended you make sure you have backups of both your Jellyfin config and data directories.
-
-The directories you should back up are listed on the [Jellyfin configuration docs page](https://jellyfin.org/docs/general/administration/configuration/) under **Server Paths**.
-
-You can read the [official 10.11.0 blog post](https://jellyfin.org/posts/jellyfin-release-10.11.0) for more details about 10.11. Definitely upgrade directly to 10.11.7, though.


### PR DESCRIPTION
- Remove unused "upgrading" response I added last time. It didn't end up being needed.
- Make logs location for docker more clear in the "logs" response