### PR TITLE
add devroom message

### DIFF
--- a/devroom.md
+++ b/devroom.md
@@ -1,0 +1,3 @@
+This room is reserved for discussing the development and design of Jellyfin and Jellyfin clients. Please do not use it to advertise or promote your client, plugin, or other project.
+
+For troubleshooting and support, use #jellyfin-troubleshooting:matrix.org .


### PR DESCRIPTION
A bunch of people use the devrooms for troubleshooting or advertising.

This adds `devroom` to the commands to tell them automagically to stop that BS.
I am unsure if the link to troubleshooting will actually work or not... Let me know if you want that removed or changed :+1: 