### PR TITLE
Correcting slashes in windows path

### DIFF
--- a/logs.md
+++ b/logs.md
@@ -5,7 +5,7 @@ The logfiles are found in the same place as ffmpeg logs, right in the dashboard.
 If you dont have access to the dashboard you can find your logfiles in the following locations:
 
 - For Linux: `/var/lib/jellyfin/logs`
-- For Windows: `%programdata%\jellyfin\logs`
+- For Windows: `%programdata%\Jellyfin\Server\logs`
 - For Docker: On the docker host, the directory you map in as /config will have a "logs" directory in it.
 
 We recommend an external site like

--- a/logs.md
+++ b/logs.md
@@ -5,7 +5,7 @@ The logfiles are found in the same place as ffmpeg logs, right in the dashboard.
 If you dont have access to the dashboard you can find your logfiles in the following locations:
 
 - For Linux: `/var/lib/jellyfin/logs`
-- For Windows: `%programdata%/jellyfin/logs`
+- For Windows: `%programdata%\jellyfin\logs`
 - For Docker: On the docker host, the directory you map in as /config will have a "logs" directory in it.
 
 We recommend an external site like


### PR DESCRIPTION
Logs response uses forward slashes in windows path instead of back slashes.